### PR TITLE
Enable ContinuousIntegrationBuild flag in CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         run: dotnet restore "${{ env.sln-path }}"
 
       - name: Build debug
-        run: dotnet build "${{ env.sln-path }}" --no-restore -c Debug
+        run: dotnet build "${{ env.sln-path }}" --no-restore -c Debug -p:ContinuousIntegrationBuild=true
 
       - name: Test
         run: dotnet test "${{ env.sln-path }}" --no-build --logger "trx;LogFileName=test-results.trx" || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         run: dotnet test "${{ env.sln-path }}" --no-restore -c Release
 
       - name: Build release
-        run: dotnet build "${{ env.sln-path }}" --no-restore -c Release -o "${{ env.build-dir }}"
+        run: dotnet build "${{ env.sln-path }}" --no-restore -c Release -o "${{ env.build-dir }}" -p:ContinuousIntegrationBuild=true
 
       - name: Upload artifact - binaries
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary
This change enables the `ContinuousIntegrationBuild` MSBuild property in both the debug and release CI build steps to ensure consistent build behavior in continuous integration environments.

## Key Changes
- Added `-p:ContinuousIntegrationBuild=true` flag to the debug build step in `build.yml`
- Added `-p:ContinuousIntegrationBuild=true` flag to the release build step in `release.yml`

## Details
The `ContinuousIntegrationBuild` property is an MSBuild flag that enables deterministic builds and other CI-specific optimizations. By setting this property to `true` during CI builds, we ensure that:
- Builds are reproducible and deterministic
- Build timestamps and other non-deterministic elements are handled consistently
- The build environment is properly identified as a CI environment for any conditional logic in project files

https://claude.ai/code/session_01Y83dwmurNPzRFcZA7jRUh8